### PR TITLE
Added module ImageSorter to the directory

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -326,4 +326,20 @@
       <psget:ProjectUrl>http://poshcode.org/3158</psget:ProjectUrl>
     </psget:properties>
   </entry>
+
+  <entry>
+    <id>ImageSorter</id>
+    <title type="text">Images importer</title>
+    <summary type="text">Imports images from the folder and store them into the taken date named subfolders.</summary>
+    <updated>2012-05-24T00:00:00+00:00</updated>
+    <author>
+      <name>Igor Tamashchuk</name>
+      <email>legigor@gmail.com</email>
+      <uri>http://igor.quatrocode.com/</uri>
+    </author>
+    <content type="text/plain" src="https://raw.github.com/legigor/ImageSorter/master/ImageSorter.psm1" />
+    <psget:properties>
+      <psget:ProjectUrl>https://github.com/legigor/ImageSorter</psget:ProjectUrl>
+    </psget:properties>
+  </entry>
 </feed>


### PR DESCRIPTION
# Images Importer

Imports images from the folder and store them into the taken date named subfolders.
## Examples

To import all images recursively from the current folder to the .\Imported subfolder just call:

```
imimg
```

or

```
Import-Images
```

If source or destintion paths re different from the defaults, few params are also availble to setup:

```
Import-Images -SourceDir:"C:\Camera" -DestinationDir:"C:\MyPics"
```

Images are removing from the sources folder by defult. In case if you want to keem them, use special param:

```
Import-Images -DontRemoveFilesAfterImport
```
## Credits
- http://blogs.technet.com/b/jamesone/archive/2007/07/13/exploring-photographic-exif-data-using-powershell-of-course.aspx
- http://pastebin.com/w0Hn5LCv
## Licence

Feel free to do everything you want
