### PR TITLE
fix entry for pscx - should resolve issue #44

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -248,7 +248,7 @@
       <name>Keith Hill</name>
       <uri>http://rkeithhill.wordpress.com/</uri>
     </author>
-    <content type="application/zip" src="http://download.codeplex.com/Download/Release?ProjectName=pscx&amp;DownloadId=121340&amp;FileTime=129181939650730000&amp;Build=18924" />
+    <content type="application/zip" src="https://github.com/psget/psget_repository/raw/master/Modules/PSCX/Pscx-2.0.0.1.zip" />
     <psget:properties>
       <psget:ProjectUrl>http://pscx.codeplex.com/</psget:ProjectUrl>
     </psget:properties>


### PR DESCRIPTION
This should address the issue I created at https://github.com/psget/psget/issues/44

NOTE: this isn't an ideal fix since the new url is tied to a particular build number, but it at least gets 'install-module pscx' working until pscx provides a better answer.

As mentioned in the issue, I've asked PSCX to provide a better mechanism for getting the latest release build.

http://pscx.codeplex.com/workitem/32775

As per wiki directions, I ran install-module locally to test that the new entry works (I had to add -force since I already had it installed)

```
PS C:\Users\james\Documents\GitHub\psget> install-module pscx -DirectoryUrl "file://${pwd}/Directory.xml" -force
Module pscx was successfully installed.
```
