### PR TITLE
update Pester repo url

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -189,9 +189,9 @@
       <uri>http://scottmuc.com/</uri>
       <email>scottmuc@gmail.com</email>
     </author>
-    <content type="application/zip" src="https://github.com/scottmuc/Pester/zipball/master" />
+    <content type="application/zip" src="https://github.com/pester/Pester/zipball/master" />
     <psget:properties>
-      <psget:ProjectUrl>https://github.com/scottmuc/Pester</psget:ProjectUrl>
+      <psget:ProjectUrl>https://github.com/pester/Pester</psget:ProjectUrl>
     </psget:properties>
   </entry>
   <entry>


### PR DESCRIPTION
A little while ago I moved Pester to a github organisation, thus breaking psget's ability to install Pester. This should fix that.
