### PR TITLE
Makes destination path selection more tolerant of mixed casing and trailing backslashes (or lack thereof)

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -187,10 +187,10 @@ process {
         $ModulePaths = $Env:PSModulePath -split ';'
         if ($Global) {
             $ExpectedSystemModulePath = Join-Path -Path $PSHome -ChildPath Modules
-            $Destination = $ModulePaths | Where-Object { $_ -eq $ExpectedSystemModulePath}
+            $Destination = $ModulePaths | Where-Object { $_.TrimEnd('\') -ieq $ExpectedSystemModulePath.TrimEnd('\')}
         } else {
             $ExpectedUserModulePath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath WindowsPowerShell\Modules
-            $Destination = $ModulePaths | Where-Object { $_ -eq $ExpectedUserModulePath}
+            $Destination = $ModulePaths | Where-Object { $_.TrimEnd('\') -ieq $ExpectedUserModulePath.TrimEnd('\')}
         }
         if (-not $Destination) {
             $Destination = $ModulePaths | Select-Object -Index 0


### PR DESCRIPTION
On some systems `$PSModulePath` and `$PSHome` have different capitalisation and inconsistent trailing backslashes.  This causes the logic that drives the `-Global` option to not work and all modules simply fall-back to installing as a user-specific module.
