### PR TITLE
Issue #69 Get-PsGetModuleInfo retrieves and displays additional metadata from xml

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -580,14 +580,18 @@ function Get-PsGetModuleInfo {
                     else { "GET" }
         
                 New-Object PSObject -Property @{
-                    "Title" = $_.title.innertext
-                    "Id" = $_.id
-                    "Type" = $Type
-                    "DownloadUrl" = $_.content.src
-                    "Verb" = $Verb
+                    Title = $_.title.innertext
+                    Description = $_.summary.'#text'
+                    Updated = [DateTime]$_.updated
+                    Author= $_.author.name
+                    Id = $_.id
+                    Type = $Type
+                    DownloadUrl = $_.content.src
+                    Verb = $Verb
+                    ModuleUrl = $_.properties.ProjectUrl                    
                 } |
                     Add-Member -MemberType AliasProperty -Name ModuleName -Value Title -PassThru |
-                    Add-Member -MemberType AliasProperty -Name ModuleUrl -Value DownloadUrl -PassThru
+                    Select-Object Title, ModuleName, Id, Description, Updated, Type, Verb, ModuleUrl,DownloadUrl
             }
     }
 <#


### PR DESCRIPTION
Modified the return objects from Get-PsGetModuleInfo with the following:
Added description, updated, and author name
Modified moduleurl to point to properties.projecturl
Ensure that output always comes out in the same order

Will create another issue.  There should be a format file for these objects.  There's no reason to default showing all 3 properties with the same data.

I've tried two times to get the diff data to show the true diff, but for some reason it keeps showing that I updated the entire file.  The diff in the github windows client shows the true diff prior to the commit, but once I commit it gets blown away.
