### PR TITLE
Fixing a bug where no User environment variable for PSModulePath caused an error in Canonicolize-Path

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -1229,7 +1229,7 @@ function Import-GlobalEnvironmentVariableToSession {
 
     #Path types (i.e. PATH or PSModulePath) of variables are concatenated from the Machine and User scopes
     if(("path","psmodulepath") -icontains $VariableName) {
-        $newSessionValue = ([Environment]::GetEnvironmentVariable($variableName, "User") + ";" +  [Environment]::GetEnvironmentVariable($variableName, "Machine")) 
+        $newSessionValue = ([Environment]::GetEnvironmentVariable($variableName, "User") + ";" +  [Environment]::GetEnvironmentVariable($variableName, "Machine")).Trim(';') 
     } else {
         #The User value has precendence over the Machine value
         $newSessionValue = [Environment]::GetEnvironmentVariable($variableName, "User")


### PR DESCRIPTION
_NOTE_ for some reason Git is showing unchanged lines as having changed, I don't know why. The only line which has changed is line 1232 to Trim additional semicolons which break the way we "-split ';'" on the PSModulePath causing empty array elements

Error shows when installing a PowerShell module into the Global level

Canonicolize-Path : Cannot bind argument to parameter 'Path' because it
is an empty string.
At C:\PsGet\PsGet.psm1:947 char:96
- ... onicolize-Path $_ })   -contains (Canonicolize-Path $Destination)
-                    ~~
- CategoryInfo          : InvalidData: (:) [Canonicolize-Path],
  ParameterBindingValidationException
- FullyQualifiedErrorId :
  ParameterArgumentValidationErrorEmptyStringNotAllowed,Canonicolize-Path
