### PR TITLE
Adding the ability to install a PowerShell module under a different name

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -278,7 +278,7 @@ process {
     #Add the Destination path to the User or Machine environment    
     AddPathToPSModulePath -Scope $moduleEnvironmentVariableScope -PathToAdd $Destination -PersistEnvironment:$PersistEnvironment
     
-    InstallModuleFromLocalFolder -SourceFolderPath:$TempModuleFolderPath -ModuleName:$ModuleName -Destination $Destination -DoNotImport:$DoNotImport -AddToProfile:$AddToProfile -Update:$Update -Global:$Global
+    InstallModuleFromLocalFolder -SourceFolderPath:$TempModuleFolderPath -ModuleName:$ModuleName -Destination $Destination -DoNotImport:$DoNotImport -AddToProfile:$AddToProfile -Update:$Update 
 }
 
 <#
@@ -962,8 +962,7 @@ Param(
     [String]$Destination,    
     [Switch]$DoNotImport = $false,
     [Switch]$AddToProfile = $false,
-    [Switch]$Update = $false,
-    [Switch]$Global = $false
+    [Switch]$Update = $false
 )    
     # TODO Handle situation when $_ is null (e.g. $Env:PSModulePath = ";Aaa;")
     $IsDestinationInPSModulePath = ($Env:PSModulePath -split ";" | foreach { Canonicolize-Path $_ })   -contains (Canonicolize-Path $Destination)
@@ -1022,18 +1021,13 @@ Param(
     
     if ($IsDestinationInPSModulePath -and $AddToProfile) {
         # WARNING $Profile is empty on Win2008R2 under Administrator
-        if ($Global) {
-            $AllProfile = $PROFILE.AllUserAllHosts
-        }
-        else {
-            $AllProfile = $PROFILE.CurrentUserAllHosts
-        }
+        $AllProfile = $PROFILE
         if(!(Test-Path $AllProfile)) {
             Write-Verbose "Creating PowerShell profile...`n$AllProfile"
             New-Item $AllProfile -Type File -Force -ErrorAction Stop
         }
         if (Select-String $AllProfile -Pattern "Import-Module $ModuleName"){
-            Write-Verbose "Import-Module $ModuleName command already in the profile"
+            Write-Verbose "Import-Module $ModuleName command already in your profile"
         } else {
             $Signature = Get-AuthenticodeSignature -FilePath $AllProfile
             if ($Signature.Status -eq 'Valid') {


### PR DESCRIPTION
We develop a PowerShell module that has work being done on it in different branches

This change allows us to install the module under different names to be able to switch between them, an example of this is on our TFS build server where we need to have the release version of the module available (using the default module name), but we also want to be able to use development versions of the module so currently we manually rename the folder and file, so and it would be nice for this to be part of the Install-Module function.
