### PR TITLE
Adding the ability to install the PowerShell module under an alternative name

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -415,7 +415,7 @@
     <id>TabExpansion++</id>
     <title type="text">TabExpansion++</title>
     <summary type="text">A set of PowerShell scripts which provide Git/PowerShell integration</summary>
-    <updated>2011-12-20T02:16:10-07:00</updated>
+    <updated>2013-07-22T08:00:00-07:00</updated>
     <author>
       <name>Jason Shirk</name>
       <uri>https://github.com/lzybkr/TabExpansionPlusPlus</uri>
@@ -424,6 +424,21 @@
     <content type="application/zip" src="https://github.com/lzybkr/TabExpansionPlusPlus/zipball/master/" />
     <psget:properties>
       <psget:ProjectUrl>https://github.com/lzybkr/TabExpansionPlusPlus/</psget:ProjectUrl>
+    </psget:properties>
+  </entry>
+  <entry>
+    <id>PSReadLine</id>
+    <title type="text">PSReadLine</title>
+    <summary type="text"></summary>
+    <updated>2013-09-12T08:00:00-07:00</updated>
+    <author>
+      <name>Jason Shirk</name>
+      <uri>https://github.com/lzybkr/PSReadLine</uri>
+      <email>jason@truewheels.net</email>
+    </author>
+    <content type="application/zip" src="https://github.com/lzybkr/psreadline/raw/master/PSReadline.zip" />
+    <psget:properties>
+      <psget:ProjectUrl>http://github.com/lzybkr/PSReadLine/</psget:ProjectUrl>
     </psget:properties>
   </entry>
   <entry>

--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -412,6 +412,8 @@ function Update-Module {
 Param(
     [Parameter(ValueFromPipeline=$true, ValueFromPipelineByPropertyName=$true, Mandatory=$true, Position=0, ParameterSetName="Repo")]    
     [String]$Module,
+    [Parameter(ParameterSetName="All")]
+    [Switch]$All,
     
     [Parameter(ValueFromPipelineByPropertyName=$true)]
     [String]$Destination = $global:PsGetDestinationModulePath,
@@ -424,7 +426,21 @@ Param(
     [Switch]$AddToProfile = $false,
     [String]$DirectoryUrl = $global:PsGetDirectoryUrl
 )
-    Install-Module -Module:$Module -Destination:$Destination -ModuleHash:$ModuleHash -Global:$Global -DoNotImport:$DoNotImport -AddToProfile:$AddToProfile -DirectoryUrl:$DirectoryUrl -Update
+    if ($PSCmdlet.ParameterSetName -eq 'All') {
+        Install-Module -Module PSGet -Force -DoNotImport
+
+        Get-PsGetModuleInfo '*' |
+        Where-Object {
+            if ($PSItem.Id -ne 'PSGet') {
+                Get-Module -Name:($PSItem.ModuleName) -ListAvailable 
+            }
+        } | Install-Module -Update            
+
+        Import-Module -Name PSGet -Force
+
+    } else {
+        Install-Module -Module:$Module -Destination:$Destination -ModuleHash:$ModuleHash -Global:$Global -DoNotImport:$DoNotImport -AddToProfile:$AddToProfile -DirectoryUrl:$DirectoryUrl -Update
+    }
 <#
 .Synopsis
     Updates a module.
@@ -692,16 +708,17 @@ function Get-PsGetModuleInfo {
 function ImportModuleGlobal {
     param (
         $Name,
-        $ModuleBase
+        $ModuleBase,
+        [switch]$Force
     )
 
-    Import-Module -Name $ModuleBase -Global
+    Import-Module -Name $ModuleBase -Global -Force:$Force
 
     $IdentityExtension = [System.IO.Path]::GetExtension((Get-ModuleIdentityFile -Path $ModuleBase -ModuleName $Name))
     if ($IdentityExtension -eq '.dll') {
         # import module twice for binary modules to workaround PowerShell bug:
         # https://connect.microsoft.com/PowerShell/feedback/details/733869/import-module-global-does-not-work-for-a-binary-module
-        Import-Module -Name $ModuleBase -Global
+        Import-Module -Name $ModuleBase -Global -Force:$Force
     }
 }
 
@@ -771,7 +788,7 @@ function CheckIfNeedInstallAndImportIfNot {
     }
 
     if ($DoNotImport -eq $false){
-        ImportModuleGlobal -Name $ModuleName -ModuleBase $InstalledModule.ModuleBase
+        ImportModuleGlobal -Name $ModuleName -ModuleBase $InstalledModule.ModuleBase -Force:$Update
     }
 
     Write-Verbose "$ModuleName already installed. Use -Update if you need update"
@@ -1012,11 +1029,15 @@ Param(
             throw "For some unexpected reasons module was not installed."
         }
     }
-    Write-Host "Module $ModuleName was successfully installed." -Foreground Green
+    if ($Update) {
+        Write-Host "Module $ModuleName was successfully updated." -Foreground Green
+    } else {
+        Write-Host "Module $ModuleName was successfully installed." -Foreground Green
+    }
     
     if ($DoNotImport -eq $false){
         # TODO consider rechecking hash before calling Import-Module
-        ImportModuleGlobal -Name $ModuleName -ModuleBase $ModuleFolderPath
+        ImportModuleGlobal -Name $ModuleName -ModuleBase $ModuleFolderPath -Force:$Update
     }
     
     if ($IsDestinationInPSModulePath -and $AddToProfile) {


### PR DESCRIPTION
We develop a PowerShell module that has work being done on it in different branches

This change allows us to install the module under different names to be able to switch between them, an example of this is on our TFS build server where we need to have the release version of the module available (using the default module name), but we also want to be able to use development versions of the module so currently we manually rename the folder and file, so and it would be nice for this to be part of the Install-Module function.

This is similar (but different) to feature request https://github.com/psget/psget/issues/27

_Sorry for making a new pull request to replace the one I closed, I didn't think to do the change in a new branch so I could have two independent pull requests_
