### PR TITLE
Windows Server Core support in UnzipModule

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -827,9 +827,9 @@ Function UnzipModule ($zipFile, $destPath) {
     }
 
     if ($shellFailed -and $netFailed) {
-        Write-Warning "We were unable to decompress the downloaded module file. This could mean several things:"
-        Write-Warning "1. You've disabled Windows Explorer Zip file integration and also don't have .NET 4.5 installed."
-        Write-Warning "2. You're running on a Windows Server Core installation and also don't have .NET 4.5 installed."
+        Write-Warning "We were unable to decompress the downloaded module. This tends to mean both of the following are true:"
+        Write-Warning "1. You've disabled Windows Explorer Zip file integration or are running on Windows Server Core."
+        Write-Warning "2. You don't have the .NET Framework 4.5 installed and/or are running PowerShell 2.0 or older."
         Write-Warning "You'll need to correct at least one of the above issues depending on your installation to proceed."
         $ErrorActionPreference = 'Stop'
         Write-Error "Unable to unzip downloaded module file!"


### PR DESCRIPTION
Using the Windows Shell Zip integration may not work on Server Core installations as these typically don't have the Windows Shell present unless the Administrator manually installs it at a later date. There's also the less common case where the Windows Shell is present but Zip integration has been disabled (usually by the user tweaking some Registry settings) in which case the COM calls will also fail in the same manner.

I've refactored the UnzipModule function so that it now supports unzipping using an alternate method provided by the new System.IO.Compression.ZipFile class in .NET 4.5. This has the benefit of working on all Server Core installations if it has been installed (assuming it isn't built-in depending on OS version) without needing to install the Windows Shell. If neither method works, we exit and let the user know what went wrong with some suggested steps to fix the issue.
