### PR TITLE
Pester testsuite fixed including a fix for issue #122

### DIFF
--- a/PsGet.Elevated.tests.ps1
+++ b/PsGet.Elevated.tests.ps1
@@ -1,9 +1,9 @@
 #Set-StrictMode -Version Latest
 $here = (Split-Path -parent $MyInvocation.MyCommand.Definition)
-Import-Module ($here + "\PsGet\PsGet.psm1") -Force 
+Import-Module ($here + "\PsGet\PsGet.psm1") -Force
 $verbose = $false;
 
-if(-not $pester) {        
+if(-not $pester) {
     Write-Warning "The tests for GetPsGet should be executed using the Run-Tests.ps1 script or Invoke-AllTests.cmd batch script"
     exit -1;
 }
@@ -17,25 +17,30 @@ Describe "Install-Module" {
     $UserModulePath = Get-UserModulePath
 
     Context "When modules installed globaly" {
-     
-        It "Should support installing module globally" {            
+
+        It "Should support installing module globally" {
             Install-Module -ModulePath $here\TestModules\HelloWorld.psm1  -Verbose:$verbose -Global
             "HelloWorld" | Should BeInstalledGlobally
-            Drop-Module "HelloWorld"            
+            Drop-Module "HelloWorld" -Global
         }
 
-        It "Should add common modules folder to the env variables" {            
+        It "Should add common modules folder to the env variables" {
+            Backup-PSModulePathVariable -Scope "Machine"
+            Backup-PSModulePathVariable -Scope "User"
 
+            try {
             Remove-PathFromPSModulePath -PathToRemove $global:CommonGlobalModuleBasePath -PersistEnvironment -Scope "Machine"
-            Remove-PathFromPSModulePath -PathToRemove $global:CommonGlobalModuleBasePath -PersistEnvironment -Scope "User"  
+            Remove-PathFromPSModulePath -PathToRemove $global:CommonGlobalModuleBasePath -PersistEnvironment -Scope "User"
 
             Install-Module -ModulePath $here\TestModules\HelloWorld.psm1 -Verbose:$verbose -Force -Global
-            
+
             $Env:PSModulePath.Contains($global:CommonGlobalModuleBasePath) | Should Be $True
-            
-            Drop-Module "HelloWorld"
+
+            Drop-Module "HelloWorld" -Global
+            } catch {
+                Restore-PSModulePathVariable -Scope "Machine"
+                Restore-PSModulePathVariable -Scope "User"
+            }
         }
     }
-
-
 }

--- a/PsGetPesterAssertionExtensions.ps1
+++ b/PsGetPesterAssertionExtensions.ps1
@@ -97,7 +97,7 @@ function PesterBeInPSModulePath {
     $Module
     )
 
-   $modulePath = $UserModulePath
+    $modulePath = $UserModulePath
     if($args -and $args[0] -and (Test-Path $args[0])) {
         $modulePath = $args[0]
     }
@@ -105,12 +105,18 @@ function PesterBeInPSModulePath {
     $expectedInstallationPath = Join-Path -Path $ModulePath -ChildPath $Module
     $baseFilename = join-path $expectedInstallationPath $Module
 
-    #Get the module by name
-    $foundmodule = get-module -Name $module -ListAvailable
-    $foundModuleInExactLocation = $foundmodule|where {[io.path]::GetDirectoryName($_.Path) -like $expectedInstallationPath}
+    try {
+        #Get the module by name
+        $foundmodule = get-module -Name $module -ListAvailable
+        $foundModuleInExactLocation = $foundmodule|where {[io.path]::GetDirectoryName($_.Path) -like $expectedInstallationPath}
 
-    #Verify that the module exists in the correct location
-    if(-not $foundModuleInExactLocation) {
+        #Verify that the module exists in the correct location
+        if(-not $foundModuleInExactLocation) {
+            return $false
+        }
+    } catch {
+        # Powershell v2 Get-Module returns cached entries for freshly deleted module which contains an error message instead if a path
+        # therefore GetDirectoryName throws an error which we need to catch.
         return $false
     }
 
@@ -149,7 +155,7 @@ Ensures that a module exists, can be imported, and can be listed using the $env:
 
     #Verify that the module (DLL or PSM1) exists
     if (-not (Test-Path "$baseFileName.psm1") -and -not (Test-Path "$baseFileName.dll")){
-		throw "Module $Module was not installed at '$baseFileName.psm1' or '$baseFileName.dll'"        
+		throw "Module $Module was not installed at '$baseFileName.psm1' or '$baseFileName.dll'"
 	}
 
     return $true
@@ -176,7 +182,7 @@ Ensures that a module exists, can be imported, and can be listed using the $env:
 
     #Verify that the module (DLL or PSM1) exists
     if (-not (Test-Path "$baseFileName.psm1") -and -not (Test-Path "$baseFileName.dll")){
-        throw "Module $Module was not installed at '$baseFileName.psm1' or '$baseFileName.dll'"        
+        throw "Module $Module was not installed at '$baseFileName.psm1' or '$baseFileName.dll'"
     }
 
     return $true


### PR DESCRIPTION
The testsuite does not polute the environment-variables and the PSModulePath anymore and the ModuleHash tests avoid issues caused by git line ending transformation.

Testsuite was broken at least since merge in commit  fe2cc3f33182e4f384c81e5fb5210c9b6ea174fc.

Testsuite runs successfully in an elevated shell with Powershell v2 and v3.

Sorry for all the unnecessary line ending changes. The editor did the normalization automatically on save.
