### PR TITLE
Adding UseDefaultCredentials to each instance of WebClient

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -452,6 +452,7 @@ function Get-PsGetModuleInfo {
     )
     begin {
         $client = (new-object Net.WebClient)
+		$client.UseDefaultCredentials = $true
         $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 
         $PsGetDataPath = Join-Path -Path $Env:APPDATA -ChildPath psget
@@ -1365,6 +1366,7 @@ function Invoke-DownloadModuleFromWeb {
 
     Write-Verbose "Downloading module from $DownloadUrl"
     $client = (new-object Net.WebClient)
+	$client.UseDefaultCredentials = $true
     $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
     $downloadFilePath = Join-Path -Path $tempfolderPath -ChildPath 'download'
     if ($Verb -eq 'POST') {
@@ -1903,6 +1905,7 @@ function Invoke-DownloadNuGetPackage {
     )
     process {
         $WebClient = New-Object -TypeName System.Net.WebClient
+		$WebClient.UseDefaultCredentials = $true
         $WebClient.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
 
         if (-not $Source.EndsWith('/')) {


### PR DESCRIPTION
Setting UseDefaultCredentials to $true allows PsGet to work with my company's internal Nuget feed, ProGet.