### PR TITLE
Updated ProtectedData URL with permanent link

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -832,7 +832,7 @@
       <uri>http://davewyatt.wordpress.com/</uri>
       <email>dlwyatt115@gmail.com</email>
     </author>
-    <content type="application/zip" src="https://github.com/dlwyatt/ProtectedData/releases/download/v3.0/ProtectedData.zip" />
+    <content type="application/zip" src="http://onedrive.live.com/download?resid=A2EBA8D8AFA70CF%2114264" />
     <psget:properties>
       <psget:ProjectUrl>https://github.com/dlwyatt/ProtectedData</psget:ProjectUrl>
     </psget:properties>


### PR DESCRIPTION
Instead of having to update the PSGet directory every time I make a new release, I'll just upload the zip file to my OneDrive account from now on.  The latest version will always be avaialble at that link.
