### PR TITLE
Switch NuGet query format to support v2 feeds

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -1910,7 +1910,7 @@ function Invoke-DownloadNuGetPackage {
         }
 
         Write-Verbose "Querying '$Source' repository for package with Id '$NuGetPackageId'"
-        $Url = "{1}Packages()?`$filter=tolower(Id)+eq+'{0}'&`$orderby=Id" -f $NuGetPackageId.ToLower(), $Source
+        $Url = "{1}Packages(Id='{0}')?`$orderby=Id" -f $NuGetPackageId, $Source
         Write-Debug "NuGet query url: $Url"
 
         try {


### PR DESCRIPTION
Pull request for issue #182.

The original OData query works for NuGet v1 protocol but fails on any feed that is only NuGet v2 and higher. Given NuGet v2 protocol has been out for quite some time, it makes sense to update.