### PR TITLE
Add PsBamboo to Directory.xml

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -1173,4 +1173,18 @@
       <psget:ProjectUrl>https://github.com/gildas/posh-vpn</psget:ProjectUrl>
     </psget:properties>
   </entry>
+  <entry>
+    <id>PsBamboo</id>
+    <title type="text">PsBamboo</title>
+    <summary type="text">PowerShell module for Bamboo REST API</summary>
+    <updated>2015-10-04T00:00:00-00:00</updated>
+    <author>
+      <name>Akos Murati</name>
+      <uri>http://murati.hu</uri>
+    </author>
+    <content type="application/zip" src="https://bitbucket.org/murati-hu/psbamboo/get/master.zip" />
+    <psget:properties>
+      <psget:ProjectUrl>https://bitbucket.org/murati-hu/psbamboo</psget:ProjectUrl>
+    </psget:properties>
+  </entry>
 </feed>


### PR DESCRIPTION
Hi,

PsBamboo is a new PowerShell module that provides a wrapper for Bamboo REST API to allow easier access and manipulation of Bamboo resources in a scriptable  manner.

This change adds the new module references into the Directory.xml file. It doesn't require any post-installation script to be executed. The new entry was tested and installed successfully with the local -DirectoryUrl parameter.

Would you please review and merge this PR if you are OK with it?

Thank you and Regards,
Akos Murati
