### PR TITLE
Support for proxy server

### DIFF
--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -39,7 +39,7 @@ function Get-File {
     }
     else {
         $client = (New-Object Net.WebClient)
-        $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+        $client.UseDefaultCredentials = $true
         if (Find-Proxy) {
             $proxy = Get-Proxy
             Write-Host "Proxy detected"

--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -70,7 +70,7 @@ function Install-PsGet {
     }
     New-Item -Path ($Destination + "\PsGet\") -ItemType Directory -Force | Out-Null
     Write-Host 'Downloading PsGet from https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1'
-    Get-File -Url "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1" -SaveToLocation $Destination + "\PsGet\PsGet.psm1"
+    Get-File -Url "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1" -SaveToLocation "$Destination\PsGet\PsGet.psm1"
 
     $executionPolicy = (Get-ExecutionPolicy)
     $executionRestricted = ($executionPolicy -eq "Restricted")

--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -1,3 +1,57 @@
+function Find-Proxy() {
+    if ((Test-Path Env:HTTP_PROXY) -Or (Test-Path Env:HTTPS_PROXY)) {
+        return $true
+    }
+    Else {
+        return $false
+    }
+}
+
+function Get-Proxy() {
+    if (Test-Path Env:HTTP_PROXY) {
+        return $Env:HTTP_PROXY
+    }
+    ElseIf (Test-Path Env:HTTPS_PROXY) {
+        return $Env:HTTPS_PROXY
+    }
+}
+
+function Get-File {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [String] $Url,
+
+        [Parameter(Mandatory=$true)]
+        [String] $SaveToLocation
+    )
+    $command = (Get-Command Invoke-WebRequest -ErrorAction SilentlyContinue)
+    if($command -ne $null) {
+        if (Find-Proxy) {
+            $proxy = Get-Proxy
+            Write-Host "Proxy detected"
+            Write-Host "Using proxy address $proxy"
+            Invoke-WebRequest -Uri $Url -OutFile $SaveToLocation -Proxy $proxy
+        }
+        else {
+            Invoke-WebRequest -Uri $Url -OutFile $SaveToLocation
+        }
+    }
+    else {
+        $client = (New-Object Net.WebClient)
+        $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+        if (Find-Proxy) {
+            $proxy = Get-Proxy
+            Write-Host "Proxy detected"
+            Write-Host "Using proxy address $proxy"
+            $webproxy = new-object System.Net.WebProxy
+            $webproxy.Address = $proxy
+            $client.proxy = $webproxy
+        }
+        $client.DownloadFile($Url, $SaveToLocation)
+    }
+}
+
 function Install-PsGet {
     $ModulePaths = @($env:PSModulePath -split ';')
     # $PsGetDestinationModulePath is mostly needed for testing purposes,
@@ -16,9 +70,7 @@ function Install-PsGet {
     }
     New-Item -Path ($Destination + "\PsGet\") -ItemType Directory -Force | Out-Null
     Write-Host 'Downloading PsGet from https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1'
-    $client = (New-Object Net.WebClient)
-    $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
-    $client.DownloadFile("https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1", $Destination + "\PsGet\PsGet.psm1")
+    Get-File -Url "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1" -SaveToLocation $Destination + "\PsGet\PsGet.psm1"
 
     $executionPolicy = (Get-ExecutionPolicy)
     $executionRestricted = ($executionPolicy -eq "Restricted")


### PR DESCRIPTION
Support for proxy detection using HTTP_PROXY and HTTPS_PROXY environment variables during PsGet installation, as referenced in #120 

Detects present of proxy environment variable and uses it, also uses Invoke-WebRequest if available

Currently I've only applied this to GetPsGet.ps1, and wanted to get feedback on the approach before apply it to PsGet.psm1. As for Invoke-WebRequest, I think some rework is going to be required to support the current use of additional headers and the Net.WebClient DownloadString method.

Thoughts?