### PR TITLE
Allow PSGet to be installed from a different Repository and fix check for Module name

### DIFF
--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -53,6 +53,13 @@ function Get-File {
 }
 
 function Install-PsGet {
+  
+    param (
+      [string]
+      # URL to the respository to download PSGet from
+      $url = "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1"
+    )
+  
     $ModulePaths = @($env:PSModulePath -split ';')
     # $PsGetDestinationModulePath is mostly needed for testing purposes,
     if ((Test-Path -Path Variable:PsGetDestinationModulePath) -and $PsGetDestinationModulePath) {
@@ -69,8 +76,8 @@ function Install-PsGet {
         }
     }
     New-Item -Path ($Destination + "\PsGet\") -ItemType Directory -Force | Out-Null
-    Write-Host 'Downloading PsGet from https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1'
-    Get-File -Url "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1" -SaveToLocation "$Destination\PsGet\PsGet.psm1"
+    Write-Host ('Downloading PsGet from {0}' -f $url)
+    Get-File -Url $url -SaveToLocation "$Destination\PsGet\PsGet.psm1"
 
     $executionPolicy = (Get-ExecutionPolicy)
     $executionRestricted = ($executionPolicy -eq "Restricted")

--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -1,3 +1,8 @@
+
+param (
+  $url = "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1"
+)
+
 function Find-Proxy() {
     if ((Test-Path Env:HTTP_PROXY) -Or (Test-Path Env:HTTPS_PROXY)) {
         return $true
@@ -57,7 +62,7 @@ function Install-PsGet {
     param (
       [string]
       # URL to the respository to download PSGet from
-      $url = "https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1"
+      $url
     )
   
     $ModulePaths = @($env:PSModulePath -split ';')
@@ -111,4 +116,4 @@ Or visit http://psget.net
 "@
 }
 
-Install-PsGet
+Install-PsGet -Url $url

--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -1,4 +1,11 @@
 function Install-PsGet {
+  
+    param (
+      [string]
+      # Repository to download PSGet from
+      $repo = "https://github.com/psget/psget/raw/master/PsGet"
+    )
+  
     $ModulePaths = @($env:PSModulePath -split ';')
     # $PsGetDestinationModulePath is mostly needed for testing purposes,
     if ((Test-Path -Path Variable:PsGetDestinationModulePath) -and $PsGetDestinationModulePath) {
@@ -15,10 +22,13 @@ function Install-PsGet {
         }
     }
     New-Item -Path ($Destination + "\PsGet\") -ItemType Directory -Force | Out-Null
-    Write-Host 'Downloading PsGet from https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1'
+    Write-Host ('Downloading PsGet from {0}/PsGet.psm1' -f $repo)
     $client = (New-Object Net.WebClient)
     $client.Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
-    $client.DownloadFile("https://github.com/psget/psget/raw/master/PsGet/PsGet.psm1", $Destination + "\PsGet\PsGet.psm1")
+    
+    # Build up the URl to download the fil from
+    $url = "{0}/PsGet.psm1" -f $repo
+    $client.DownloadFile($url, $Destination + "\PsGet\PsGet.psm1")
 
     $executionPolicy = (Get-ExecutionPolicy)
     $executionRestricted = ($executionPolicy -eq "Restricted")

--- a/GetPsGet.ps1
+++ b/GetPsGet.ps1
@@ -1,9 +1,12 @@
+
+param ( $repo = "https://github.com/psget/psget/raw/master/PsGet" )
+
 function Install-PsGet {
   
     param (
       [string]
       # Repository to download PSGet from
-      $repo = "https://github.com/psget/psget/raw/master/PsGet"
+      $repo
     )
   
     $ModulePaths = @($env:PSModulePath -split ';')
@@ -62,4 +65,4 @@ Or visit http://psget.net
 "@
 }
 
-Install-PsGet
+Install-PsGet -repo $repo

--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -1636,7 +1636,7 @@ function Install-ModuleToDestination {
 
         $isDestinationInPSModulePath = $env:PSModulePath.Contains($Destination)
         if ($isDestinationInPSModulePath) {
-            if (-not (Get-Module $ModuleName -ListAvailable)) {
+            if (-not (Get-Module $InstallWithModuleName -ListAvailable)) {
                 throw 'For some unexpected reasons module was not installed.'
             }
         }
@@ -1647,14 +1647,14 @@ function Install-ModuleToDestination {
         }
 
         if ($Update) {
-            Write-Host "Module $ModuleName was successfully updated." -Foreground Green
+            Write-Host "Module $InstallWithModuleName was successfully updated." -Foreground Green
         }
         else {
-            Write-Host "Module $ModuleName was successfully installed." -Foreground Green
+            Write-Host "Module $InstallWithModuleName was successfully installed." -Foreground Green
         }
 
         if (-not $DoNotImport) {
-            Import-ModuleGlobally -ModuleName:$ModuleName -ModuleBase:$targetFolderPath -Force:$Update
+            Import-ModuleGlobally -ModuleName:$InstallWithModuleName -ModuleBase:$targetFolderPath -Force:$Update
         }
 
         if ($isDestinationInPSModulePath -and $AddToProfile) {
@@ -1665,8 +1665,8 @@ function Install-ModuleToDestination {
                     New-Item $PROFILE -Type File -Force -ErrorAction Stop
                 }
 
-                if (Select-String $PROFILE -Pattern "Import-Module $ModuleName") {
-                    Write-Verbose "Import-Module $ModuleName command already in your profile"
+                if (Select-String $PROFILE -Pattern "Import-Module $InstallWithModuleName") {
+                    Write-Verbose "Import-Module $InstallWithModuleName command already in your profile"
                 }
                 else {
                     $signature = Get-AuthenticodeSignature -FilePath $PROFILE
@@ -1675,8 +1675,8 @@ function Install-ModuleToDestination {
                         Write-Error "PsGet cannot modify code-signed profile '$PROFILE'."
                     }
                     else {
-                        Write-Verbose "Add Import-Module $ModuleName command to the profile"
-                        "`nImport-Module $ModuleName" | Add-Content $PROFILE
+                        Write-Verbose "Add Import-Module $InstallWithModuleName command to the profile"
+                        "`nImport-Module $InstallWithModuleName" | Add-Content $PROFILE
                     }
                 }
             }


### PR DESCRIPTION
Two changes are included in this pull request.

**Allow PSGet to be installed from different repo**
The ```GetPsGet.ps1``` assumes that PSGet will be installed from the main GitHub repo.  This is fine most of the time but if working on fork or even a different repo it is beneficial to be able to pass the URL to the repo to download from.  The default is the main PsGet github repo.  For example:

```GetPsGet -url "http://myrepo.com/psget.git```

**Fix check for Modules installed with different Name**
When a module is installed with a different name using the ```InstallWithModuleName``` parameter the module was still using ```ModuleName``` to determine if the module was installed.  This meant that the wrong name was being looked for in the installed modules and thus the PsGet error about the module not being installed was thrown.

This has now been changed so that the correct name is used for looking for the module.
