### PR TITLE
Update URI for PSReadline

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -494,7 +494,7 @@
       <uri>https://github.com/lzybkr/PSReadLine</uri>
       <email>jason@truewheels.net</email>
     </author>
-    <content type="application/zip" src="https://github.com/lzybkr/PSReadLine/releases/download/Latest/PSReadline.zip" />
+    <content type="application/zip" src="http://aka.ms/psreadline-latest" />
     <psget:properties>
       <psget:ProjectUrl>http://github.com/lzybkr/PSReadLine/</psget:ProjectUrl>
     </psget:properties>


### PR DESCRIPTION
I'm changing the URL so I can redirect to newer releases w/o changing a tag on GitHub and w/o needing to update the PSGet directory.

It would be a nice feature to have in PSGet - to automatically grab the latest from GitHub if, e.g. the directory just pointed to the repo.