### PR TITLE
Move posh-svn to iMobile3

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -195,14 +195,14 @@
     <id>posh-svn</id>
     <title type="text">posh-svn</title>
     <summary type="text">SVN prompt/tab expansion for Windows PowerShell</summary>
-    <updated>2011-05-01T15:52:10-07:00</updated>
+    <updated>2016-03-11T14:58:21-05:00</updated>
     <author>
-      <name>Jeremy Skinner</name>
-      <uri>http://www.jeremyskinner.co.uk</uri>
+      <name>iMobile3</name>
+      <uri>http://www.imobile3.com</uri>
     </author>
-    <content type="application/zip" src="https://github.com/JeremySkinner/posh-svn/zipball/master" />
+    <content type="application/zip" src="https://github.com/imobile3/posh-svn/zipball/master" />
     <psget:properties>
-      <psget:ProjectUrl>https://github.com/JeremySkinner/posh-svn</psget:ProjectUrl>
+      <psget:ProjectUrl>https://github.com/imobile3/posh-svn</psget:ProjectUrl>
     </psget:properties>
   </entry>
   <entry>


### PR DESCRIPTION
The `posh-svn` developer is no longer maintaining it, so move to our fork that has the latest. See https://github.com/JeremySkinner/posh-svn/issues/14 for discussion.