### PR TITLE
Fixes xml tag error in the Directory.xml file.

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -1260,7 +1260,7 @@
     <entry>
     <id>OctopusStepTemplateCi</id>
     <title type="text">OctopusStepTemplateCi</title>
-    </summary>Continuous integration for Octopus Deploy step templates</summary>
+    <summary>Continuous integration for Octopus Deploy step templates</summary>
     <updated>2016-04-16T00:00:00-00:00</updated>
     <author>
       <name>ASOS</name>


### PR DESCRIPTION
There is an format error in the Directory.xml file. It causes the Install-Module failed to parse the file.