### PR TITLE
Add CloudRemoting module to Directory.xml

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -1271,4 +1271,18 @@
       <psget:ProjectUrl>https://github.com/ASOS/OctopusStepTemplateCi</psget:ProjectUrl>
     </psget:properties>
   </entry>
+  <entry>
+    <id>CloudRemoting</id>
+    <title type="text">CloudRemoting</title>
+    <summary type="text">CloudRemoting module provides an easy and scriptable way to connect to remote machines via RDP and PSsessions with seamless key-pair or credential based authentication.</summary>
+    <updated>2016-05-01T00:00:00-00:00</updated>
+    <author>
+      <name>Akos Murati</name>
+      <uri>http://murati.hu</uri>
+    </author>
+    <content type="application/zip" src="https://github.com/murati-hu/CloudRemoting/archive/latest.zip" />
+    <psget:properties>
+      <psget:ProjectUrl>https://github.com/murati-hu/CloudRemoting</psget:ProjectUrl>
+    </psget:properties>
+  </entry>
 </feed>


### PR DESCRIPTION
Hi,

CloudRemoting is a new PowerShell module to connect to support key-pair based, password-less PSSessions and RDP sessions to EC2, Azure or other machines.

This change adds the module reference to Directory.xml file. It doesn't require any post-installation script. The new entry was tested and installed successfully with the local -DirectoryUrl parameter.

Would you please review and merge this PR if you are OK with it?

Thank you and Regards,
Akos Murati