### PR TITLE
Fix XML BOM issue with PowerShell 2

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -488,7 +488,9 @@ function Get-PsGetModuleInfo {
 
         try {
             Write-Verbose "Downloading modules repository from $DirectoryUrl"
-            $repoRaw = $client.DownloadString($DirectoryUrl)
+            $stream = $client.OpenRead($DirectoryUrl)
+            $repoXmlTemp = New-Object -TypeName System.Xml.XmlDocument
+            $repoXmlTemp.Load($stream)
             $StatusCode = 200
         }
         catch [System.Net.WebException] {
@@ -497,7 +499,7 @@ function Get-PsGetModuleInfo {
         }
 
         if ($StatusCode -eq 200) {
-            $repoXml = [xml]$repoRaw
+            $repoXml = [xml]$repoXmlTemp
 
             $CacheEntry.ETag = $client.ResponseHeaders['ETag']
             if (-not (Test-Path -Path $PsGetDataPath)) {


### PR DESCRIPTION
The Directory.xml contains UTF-8 BOM characters at the start. PowerShell
2 is not able to parse those marks on casting because the downloaded
string is UTF-8 (without BOM) encoded, but it happily works when
streaming the content directly to XmlDocument.

Fixes #207