### PR TITLE
Removed oh-my-posh from the directory

### DIFF
--- a/Directory.xml
+++ b/Directory.xml
@@ -1285,19 +1285,4 @@
       <psget:ProjectUrl>https://github.com/murati-hu/CloudRemoting</psget:ProjectUrl>
     </psget:properties>
   </entry>
-  <entry>
-    <id>oh-my-posh</id>
-    <title type="text">oh-my-posh</title>
-    <summary type="text">A bundle of useful PowerShell modules with prompt theming in ConEmu on top</summary>
-    <updated>2016-06-29T00:00:00-00:00</updated>
-    <author>
-      <name>Jan De Dobbeleer</name>
-      <uri>https://herebedragons.io/</uri>
-    </author>
-    <content type="application/zip" src="https://github.com/janjoris/oh-my-posh/zipball/master/" />
-    <psget:properties>
-      <psget:ProjectUrl>https://github.com/janjoris/oh-my-posh/</psget:ProjectUrl>
-      <psget:PostUpdateHook>none</psget:PostUpdateHook>
-    </psget:properties>
-  </entry>
 </feed>


### PR DESCRIPTION
I have to remove my module as it will no longer work due to a [change](https://github.com/JanJoris/oh-my-posh/commit/82cfaa8a1fadaa82a626ced4c28f5848c13b15ab) I made regarding versioning. As I do not have time to create a post install hook, I'll remove it and resort to install using the `-ModuleUrl` option for users willing to use PsGet.