### PR TITLE
Add Support for PowerShell Core

### DIFF
--- a/PsGet/PsGet.psm1
+++ b/PsGet/PsGet.psm1
@@ -8,17 +8,21 @@
 
 #region Setup
 
+Write-Debug 'Determine if current posh is Core or Desktop'
+$global:UseCore = $PSVersionTable.PSEdition -eq 'Core'
+$global:PowerShellRoot = if ($global:UseCore) { 'PowerShell' } else { 'WindowsPowerShell' }
+
 Write-Debug 'Set up the global scope config variables.'
 if ([Environment]::GetFolderPath('MyDocuments')) {
-    $global:UserModuleBasePath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath 'WindowsPowerShell\Modules'
+    $global:UserModuleBasePath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath "$global:PowerShellRoot\Modules"
 }
 else {
     # Support scenarios where PSGet is running without a MyDocuments special folder (e.g. executing within a DSC resource)
-    $global:UserModuleBasePath = Join-Path -Path $env:ProgramFiles -ChildPath 'WindowsPowerShell\Modules'
+    $global:UserModuleBasePath = Join-Path -Path $env:ProgramFiles -ChildPath "$global:PowerShellRoot\Modules"
 }
 
 # NOTE: Path changed to align with current MS conventions
-$global:CommonGlobalModuleBasePath = Join-Path -Path $env:ProgramFiles -ChildPath 'WindowsPowerShell\Modules'
+$global:CommonGlobalModuleBasePath = Join-Path -Path $env:ProgramFiles -ChildPath "$global:PowerShellRoot\Modules"
 
 if (-not (Test-Path -Path:variable:global:PsGetDirectoryUrl)) {
     $global:PsGetDirectoryUrl = 'https://github.com/psget/psget/raw/master/Directory.xml'
@@ -1154,7 +1158,7 @@ function Add-PathToPSModulePath {
             if ($pathValue -eq '') {
                 Write-Debug "PSModulePath for scope '$scope' was read empty. Setting PowerShell default instead."
                 if ($scope -eq 'User') {
-                    $pathValue = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath 'WindowsPowerShell\Modules'
+                    $pathValue = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath "$global:PowerShellRoot\Modules"
                 }
                 else {
                     $pathValue = Join-Path -Path $PSHOME -ChildPath 'Modules'
@@ -1872,7 +1876,7 @@ function Update-PSModulePath {
         $userModulePath = [Environment]::GetEnvironmentVariable('PSModulePath', 'User')
         if (-not $userModulePath) {
             # powershell default
-            $userModulePath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath 'WindowsPowerShell\Modules'
+            $userModulePath = Join-Path -Path ([Environment]::GetFolderPath('MyDocuments')) -ChildPath "$global:PowerShellRoot\Modules"
         }
 
         $newSessionValue = "$userModulePath;$machineModulePath;$psModulePath"


### PR DESCRIPTION
PowerShell Core is nominally the same as PowerShell, but uses a different root name for its module/profile/program files directories. This PR checks the `$PSVersionTable` for the `PSEdition` property. I checked on posh 2.0 and the null key behaved as expected, meanwhile PowerShell Core 6 correctly identified as was then able to install modules.