### PR TITLE
Use raw Github URL for GetPsGet instead of website URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,7 +8,7 @@ Installation
 
 In your prompt execute:
 
-	(new-object Net.WebClient).DownloadString("http://psget.net/GetPsGet.ps1") | iex
+	(new-object Net.WebClient).DownloadString("https://raw.githubusercontent.com/psget/psget/master/GetPsGet.ps1") | iex
 
 And if you get something like this:
 


### PR DESCRIPTION
When trying to install this tool I noticed that the website `psget.net` is no longer active and therefore the command in the instructions in the README fails. So I changed it to use the Github URL for the file, to avoid depending on an external website and to always use the latest version